### PR TITLE
Update Instructor_Notes.md

### DIFF
--- a/Instructor_Notes.md
+++ b/Instructor_Notes.md
@@ -13,6 +13,7 @@ Additionally, we recommend [Towards Data Science](https://towardsdatascience.com
 ## Courses Using OpenDS4All Materials
 
 * The University of Pennsylvania's CIS 545, Big Data Analytics, www.cis.upenn.edu/~cis545
+* See [ADOPTERS.csv](ADOPTERS.csv) for additional universities and courses that adopted some or all of the content of OpenDS4ALL.
 
 ## Background Material
 


### PR DESCRIPTION
Added the link to the ADOPTERS.csv file in the Instructor notes so that it does not look like UPenn is the only university using the OpenDS4All educational modules.

Signed-off-by: Andre de Waal <andre.dewaal@ibm.com>